### PR TITLE
Retrieval playground table and empty table

### DIFF
--- a/src/app/(home)/retrieval/mock-data.js
+++ b/src/app/(home)/retrieval/mock-data.js
@@ -1,0 +1,15 @@
+export const graphRetriever = [
+  { id: 1, rank: 1, content: 'Lorem ipsum dolor sit amet consectetur.' },
+  {
+    id: 2,
+    rank: 2,
+    content:
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores, dolore?\nAb unde accusantium similique sequi, provident magni labore voluptate quo.',
+  },
+  {
+    id: 3,
+    rank: 3,
+    content:
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Praesentium esse cumque atque!',
+  },
+];

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/ui/components/button';
 import { Heading, SecondaryText, Subheading } from '@/ui/components/heading';
 import PagePanel from '@/ui/components/page-panel';
 import { RetrievalTable } from '@/app/(home)/retrieval/retrieval-table';
+import { RetrievalOptions } from '@/app/(home)/retrieval/retrieval-options';
 
 import { useState } from 'react';
 
@@ -29,7 +30,9 @@ export default function Retrieval() {
       <Heading text="Retrieval" />
       {data ? (
         <div className="flex flex-grow flex-col gap-4 sm:gap-6">
-          <div>Options Menu</div>
+          <div className="mt-4 flex items-center justify-between">
+            <RetrievalOptions />
+          </div>
           <div className="flex-grow">
             <RetrievalTable chunks={chunks} />
             {!chunks && (

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -8,6 +8,17 @@ import PagePanel from '@/ui/components/page-panel';
 
 import { useState } from 'react';
 
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeader,
+  TableCell,
+} from '@/ui/components/table';
+import { PiBracketsCurly } from 'react-icons/pi';
+import { ImTree } from 'react-icons/im';
+
 // mock data
 import { graphRetriever } from './mock-data';
 
@@ -21,13 +32,51 @@ type Dataset = Data[];
 
 export default function Retrieval() {
   const [data, setData] = useState<Dataset | null>(null);
+  const [chunks, setChunks] = useState<Dataset | null>(graphRetriever);
 
   return (
     <PagePanel className="flex h-full flex-col">
       <Heading text="Retrieval" />
       {data ? (
-        <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">
-          <p>Data!</p>
+        <div className="flex flex-grow flex-col gap-4 sm:gap-6">
+          <div>Options Menu</div>
+          <div className="flex-grow">
+            <Table>
+              <TableHead>
+                <TableRow className="flex">
+                  <TableHeader className="min-w-14 flex-grow-0">
+                    Rank
+                  </TableHeader>
+                  <TableHeader className="flex-grow">Content</TableHeader>
+                  <TableCell className="flex-grow-0" />
+                </TableRow>
+              </TableHead>
+              {chunks && (
+                <TableBody>
+                  {chunks.map(chunk => (
+                    <TableRow key={chunk.id} className="flex">
+                      <TableCell className="min-w-14 flex-grow-0 text-right">
+                        {chunk.rank}
+                      </TableCell>
+                      <TableCell className="flex-grow text-wrap">
+                        {chunk.content}
+                      </TableCell>
+                      <TableCell className="flex flex-grow-0 items-center gap-4 text-zinc-500 dark:text-zinc-400">
+                        <ImTree />
+                        <PiBracketsCurly />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              )}
+            </Table>
+            {!chunks && (
+              <div className="border-b border-b-zinc-950/5 py-2 text-center text-sm/6 text-zinc-500 dark:text-zinc-400">
+                Fire a query to view the retrieved chunks.
+              </div>
+            )}
+          </div>
+          <div>Retrieval Prompt</div>
         </div>
       ) : (
         <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -61,7 +61,9 @@ export default function Retrieval() {
             <SecondaryText text="You will need to setup pipelines or import datasets to start experimenting with RAG" />
           </div>
           <div className="flex flex-row items-center gap-4">
-            <Button>Setup Connections</Button>
+            <Button onClick={() => setData(graphRetriever)}>
+              Setup Connections
+            </Button>
             <SecondaryText text="OR" />
             <Button color="secondary" onClick={() => setData(graphRetriever)}>
               Import Dataset

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -5,19 +5,9 @@ import Image from 'next/image';
 import { Button } from '@/ui/components/button';
 import { Heading, SecondaryText, Subheading } from '@/ui/components/heading';
 import PagePanel from '@/ui/components/page-panel';
+import { RetrievalTable } from '@/app/(home)/retrieval/retrieval-table';
 
 import { useState } from 'react';
-
-import {
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableHeader,
-  TableCell,
-} from '@/ui/components/table';
-import { PiBracketsCurly } from 'react-icons/pi';
-import { ImTree } from 'react-icons/im';
 
 // mock data
 import { graphRetriever } from './mock-data';
@@ -28,7 +18,7 @@ type Data = {
   content: string;
 };
 
-type Dataset = Data[];
+export type Dataset = Data[];
 
 export default function Retrieval() {
   const [data, setData] = useState<Dataset | null>(null);
@@ -41,35 +31,7 @@ export default function Retrieval() {
         <div className="flex flex-grow flex-col gap-4 sm:gap-6">
           <div>Options Menu</div>
           <div className="flex-grow">
-            <Table>
-              <TableHead>
-                <TableRow className="flex">
-                  <TableHeader className="min-w-14 flex-grow-0">
-                    Rank
-                  </TableHeader>
-                  <TableHeader className="flex-grow">Content</TableHeader>
-                  <TableCell className="flex-grow-0" />
-                </TableRow>
-              </TableHead>
-              {chunks && (
-                <TableBody>
-                  {chunks.map(chunk => (
-                    <TableRow key={chunk.id} className="flex">
-                      <TableCell className="min-w-14 flex-grow-0 text-right">
-                        {chunk.rank}
-                      </TableCell>
-                      <TableCell className="flex-grow text-wrap">
-                        {chunk.content}
-                      </TableCell>
-                      <TableCell className="flex flex-grow-0 items-center gap-4 text-zinc-500 dark:text-zinc-400">
-                        <ImTree />
-                        <PiBracketsCurly />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              )}
-            </Table>
+            <RetrievalTable chunks={chunks} />
             {!chunks && (
               <div className="border-b border-b-zinc-950/5 py-2 text-center text-sm/6 text-zinc-500 dark:text-zinc-400">
                 Fire a query to view the retrieved chunks.

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -7,6 +7,7 @@ import { Heading, SecondaryText, Subheading } from '@/ui/components/heading';
 import PagePanel from '@/ui/components/page-panel';
 import { RetrievalTable } from '@/app/(home)/retrieval/retrieval-table';
 import { RetrievalOptions } from '@/app/(home)/retrieval/retrieval-options';
+import ChatPrompt from '@/ui/widgets/playground/chat-prompt';
 
 import { useState } from 'react';
 
@@ -41,7 +42,10 @@ export default function Retrieval() {
               </div>
             )}
           </div>
-          <div>Retrieval Prompt</div>
+          <ChatPrompt
+            handleSendPrompt={() => console.log('prompt sent')}
+            isRetrievalPrompt={true}
+          />
         </div>
       ) : (
         <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -24,7 +24,7 @@ export type Dataset = Data[];
 
 export default function Retrieval() {
   const [data, setData] = useState<Dataset | null>(null);
-  const [chunks, setChunks] = useState<Dataset | null>(graphRetriever);
+  const [chunks, setChunks] = useState<Dataset | null>(null);
 
   return (
     <PagePanel className="flex h-full flex-col">
@@ -32,7 +32,7 @@ export default function Retrieval() {
       {data ? (
         <div className="flex flex-grow flex-col gap-4 sm:gap-6">
           <div className="mt-4 flex items-center justify-between">
-            <RetrievalOptions />
+            <RetrievalOptions handleClear={() => setChunks(null)} />
           </div>
           <div className="flex-grow">
             <RetrievalTable chunks={chunks} />
@@ -43,7 +43,7 @@ export default function Retrieval() {
             )}
           </div>
           <ChatPrompt
-            handleSendPrompt={() => console.log('prompt sent')}
+            handleSendPrompt={() => setChunks(graphRetriever)}
             isRetrievalPrompt={true}
           />
         </div>

--- a/src/app/(home)/retrieval/page.tsx
+++ b/src/app/(home)/retrieval/page.tsx
@@ -1,31 +1,56 @@
+'use client';
+
 import Image from 'next/image';
 
 import { Button } from '@/ui/components/button';
 import { Heading, SecondaryText, Subheading } from '@/ui/components/heading';
 import PagePanel from '@/ui/components/page-panel';
 
+import { useState } from 'react';
+
+// mock data
+import { graphRetriever } from './mock-data';
+
+type Data = {
+  id: number;
+  rank: number;
+  content: string;
+};
+
+type Dataset = Data[];
+
 export default function Retrieval() {
+  const [data, setData] = useState<Dataset | null>(null);
+
   return (
     <PagePanel className="flex h-full flex-col">
       <Heading text="Retrieval" />
-      <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">
-        <Image
-          src="/assets/chat.png"
-          alt="retrieval"
-          width={200}
-          height={200}
-          className="h-auto w-24 object-contain sm:w-[200px]"
-        />
-        <div className="flex flex-col items-center gap-1 text-center">
-          <Subheading text="You're Just One Step Away From AI-ing!" />
-          <SecondaryText text="You will need to setup pipelines or import datasets to start experimenting with RAG" />
+      {data ? (
+        <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">
+          <p>Data!</p>
         </div>
-        <div className="flex flex-row items-center gap-4">
-          <Button>Setup Connections</Button>
-          <SecondaryText text="OR" />
-          <Button color="secondary">Import Dataset</Button>
+      ) : (
+        <div className="flex flex-grow flex-col items-center justify-center gap-4 sm:gap-6">
+          <Image
+            src="/assets/chat.png"
+            alt="retrieval"
+            width={200}
+            height={200}
+            className="h-auto w-24 object-contain sm:w-[200px]"
+          />
+          <div className="flex flex-col items-center gap-1 text-center">
+            <Subheading text="You're Just One Step Away From AI-ing!" />
+            <SecondaryText text="You will need to setup pipelines or import datasets to start experimenting with RAG" />
+          </div>
+          <div className="flex flex-row items-center gap-4">
+            <Button>Setup Connections</Button>
+            <SecondaryText text="OR" />
+            <Button color="secondary" onClick={() => setData(graphRetriever)}>
+              Import Dataset
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
     </PagePanel>
   );
 }

--- a/src/app/(home)/retrieval/retrieval-options.tsx
+++ b/src/app/(home)/retrieval/retrieval-options.tsx
@@ -1,0 +1,45 @@
+import { Popover, PopoverButton, PopoverPanel } from '@/ui/components/popover';
+import { Divider } from '@/ui/components/divider';
+import { Button } from '@/ui/components/button';
+import { Tab, TabList, TabGroup } from '@/ui/components/tabs';
+import { LuArrowRightToLine } from 'react-icons/lu';
+import { BiSolidEraser } from 'react-icons/bi';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import { TbArrowsExchange } from 'react-icons/tb';
+
+export const RetrievalOptions = () => {
+  return (
+    <>
+      <div className="flex items-center gap-4">
+        <Popover>
+          <PopoverButton className="hover:bg-primary-hover flex w-[14rem] flex-row items-center justify-between rounded-lg border-zinc-200 p-2 font-sans text-sm font-medium">
+            Graph Retriever
+            <ChevronDownIcon className="h-5 w-5 fill-zinc-500 group-hover:fill-black" />
+          </PopoverButton>
+          <PopoverPanel className="ml-4 flex w-64 flex-col">
+            <Divider className="w-full" />
+            <div className="flex p-2">
+              <Button className="flex-grow">
+                <TbArrowsExchange />
+                Compare Retrievers
+              </Button>
+            </div>
+          </PopoverPanel>
+        </Popover>
+        <Button color="light" className="text-sm/6">
+          <LuArrowRightToLine />
+        </Button>
+        <Button color="secondary" className="text-sm/6">
+          <BiSolidEraser />
+          Clear
+        </Button>
+      </div>
+      <TabGroup>
+        <TabList>
+          <Tab index={0} title="Chunks" />
+          <Tab index={1} title="Generation" />
+        </TabList>
+      </TabGroup>
+    </>
+  );
+};

--- a/src/app/(home)/retrieval/retrieval-options.tsx
+++ b/src/app/(home)/retrieval/retrieval-options.tsx
@@ -7,7 +7,11 @@ import { BiSolidEraser } from 'react-icons/bi';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { TbArrowsExchange } from 'react-icons/tb';
 
-export const RetrievalOptions = () => {
+type RetrievalOptionsProps = {
+  handleClear: () => void;
+};
+
+export const RetrievalOptions = ({ handleClear }: RetrievalOptionsProps) => {
   return (
     <>
       <div className="flex items-center gap-4">
@@ -29,7 +33,7 @@ export const RetrievalOptions = () => {
         <Button color="light" className="text-sm/6">
           <LuArrowRightToLine />
         </Button>
-        <Button color="secondary" className="text-sm/6">
+        <Button color="secondary" className="text-sm/6" onClick={handleClear}>
           <BiSolidEraser />
           Clear
         </Button>

--- a/src/app/(home)/retrieval/retrieval-table.tsx
+++ b/src/app/(home)/retrieval/retrieval-table.tsx
@@ -1,0 +1,44 @@
+import { Dataset } from '@/app/(home)/retrieval/page';
+
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeader,
+  TableCell,
+} from '@/ui/components/table';
+import { PiBracketsCurly } from 'react-icons/pi';
+import { ImTree } from 'react-icons/im';
+
+export const RetrievalTable = ({ chunks }: { chunks: Dataset | null }) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow className="flex">
+          <TableHeader className="min-w-14 flex-grow-0">Rank</TableHeader>
+          <TableHeader className="flex-grow">Content</TableHeader>
+          <TableCell className="flex-grow-0" />
+        </TableRow>
+      </TableHead>
+      {chunks && (
+        <TableBody>
+          {chunks.map(chunk => (
+            <TableRow key={chunk.id} className="flex">
+              <TableCell className="min-w-14 flex-grow-0 text-right">
+                {chunk.rank}
+              </TableCell>
+              <TableCell className="flex-grow text-wrap">
+                {chunk.content}
+              </TableCell>
+              <TableCell className="flex flex-grow-0 items-center gap-4 text-zinc-500 dark:text-zinc-400">
+                <ImTree />
+                <PiBracketsCurly />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      )}
+    </Table>
+  );
+};

--- a/src/ui/widgets/playground/chat-prompt.tsx
+++ b/src/ui/widgets/playground/chat-prompt.tsx
@@ -24,14 +24,16 @@ export default function ChatPrompt({
 
   //styles for components
   const divClassName = cn(
-    'flex flex-col w-full rounded-lg border-2 border-input bg-white ring-offset-background focus-visible:outline-none resize-none overflow-hidden p-4 min-h-28 max-h-52',
+    'flex w-full rounded-lg border-2 border-input bg-white ring-offset-background focus-visible:outline-none resize-none overflow-hidden p-4 max-h-52',
     isFocused
       ? 'ring-2 ring-primary ring-opacity-50'
       : 'focus-visible:ring-2 focus-visible:ring-ring',
+    isRetrievalPrompt ? 'items-end min-h-16' : 'flex-col min-h-28',
   );
 
   const inputClassName = cn(
-    'w-full text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground placeholder:text-base border-none focus-visible:outline-none resize-none overflow-hidden min-h-6',
+    'min-h-6 w-full text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground placeholder:text-base border-none focus-visible:outline-none resize-none overflow-hidden',
+    isRetrievalPrompt ? 'pb-2 max-h-44' : '',
   );
 
   //dynamically changing the height of div and textarea when text is too big
@@ -44,7 +46,7 @@ export default function ChatPrompt({
     if (divRef.current && textareaRef.current) {
       divRef.current.style.height = 'auto';
       divRef.current.style.height = `${
-        textareaRef.current.scrollHeight + 80 //adding extra space for buttons
+        textareaRef.current.scrollHeight + (isRetrievalPrompt ? 40 : 80) //adding extra space for buttons
       }px`;
     }
   };
@@ -98,7 +100,7 @@ export default function ChatPrompt({
         </div>
       )}
       {isRetrievalPrompt && (
-        <div className="mt-4 flex flex-row items-end justify-end">
+        <div className="flex items-end">
           <Button size="sm" onClick={handleSend}>
             <div className="flex flex-row items-center gap-2">
               Run <BiPlay className="h-4 w-4" />

--- a/src/ui/widgets/playground/chat-prompt.tsx
+++ b/src/ui/widgets/playground/chat-prompt.tsx
@@ -28,7 +28,7 @@ export default function ChatPrompt({
     isFocused
       ? 'ring-2 ring-primary ring-opacity-50'
       : 'focus-visible:ring-2 focus-visible:ring-ring',
-    isRetrievalPrompt ? 'items-end min-h-16' : 'flex-col min-h-28',
+    isRetrievalPrompt ? 'items-end min-h-16 gap-4' : 'flex-col min-h-28',
   );
 
   const inputClassName = cn(


### PR DESCRIPTION
Retrieval playground page with table to display chunks of data.

Click either button on the initial screen to load the mock data. Click 'run' in the chat prompt to populate the table with mock data chunk.

This pull request corresponds to screens 2 and 3 of the figma design form the RAG Playground page.